### PR TITLE
windows_cconv.h: Don't assume Windows

### DIFF
--- a/include/windows_cconv.h
+++ b/include/windows_cconv.h
@@ -1,12 +1,16 @@
 #ifndef WINDOWS_CCONV_H
 #define WINDOWS_CCONV_H
 
+#if defined(mingw32_HOST_OS)
 #if defined(i386_HOST_ARCH)
 # define WINDOWS_CCONV stdcall
 #elif defined(x86_64_HOST_ARCH)
 # define WINDOWS_CCONV ccall
 #else
 # error Unknown mingw32 arch
+#endif
+#else
+# define WINDOWS_CCONV
 #endif
 
 #endif


### PR DESCRIPTION
The package failed to configure on non-Intel Linux with "Unknown
mingw32 arch". For some reason cabal runs this file through GCC even
on non-Windows machines. Solution is to check for `mingw32_HOST_OS`
and that is not defined, define `WINDOWS_CCONV` as nothing.